### PR TITLE
Add ALLOW_CONDA override

### DIFF
--- a/cmake/check_user_env.cmake
+++ b/cmake/check_user_env.cmake
@@ -6,9 +6,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "XL"
         message(FATAL_ERROR "ExaChem cannot be currently built with ${CMAKE_CXX_COMPILER_ID} compilers.")
 endif()
 
-if (DEFINED ENV{CONDA_PREFIX}) #VIRTUAL_ENV
-  message(FATAL_ERROR "ExaChem cannot be currently built with CONDA. \
-          Please deactivate CONDA environment.")
+if (DEFINED ENV{CONDA_PREFIX} AND NOT ALLOW_CONDA) #VIRTUAL_ENV
+  message(FATAL_ERROR "ExaChem cannot be reliably built in CONDA environments. \
+          Please deactivate CONDA or use ALLOW_CONDA=ON to override")
 endif()
 
 if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")


### PR DESCRIPTION
I am not sure what exactly makes conda an unwanted environment for building ExaChem, but I would like to try building ExaChem based on the conda-forge toolchain.